### PR TITLE
Add owningView and improve naming

### DIFF
--- a/AnchorKit/Anchorable+Constraints.swift
+++ b/AnchorKit/Anchorable+Constraints.swift
@@ -84,13 +84,12 @@ extension Anchorable {
         default:
             /**
              At this point, we're trying to setup a constraint with a non-dimensional anchor with only a constant.
-             We assume that the constraint should be related to the view's superview. If the item is a layout guide
-             or if the item is a view without a superview, we crash.
+             We assume that the constraint should be related to the item's owning view.
             */
-            guard let superview = (self as? View)?.superview else {
-                fatalError("Attempting to constrain a \(anchor) anchor using only a constant to a view that has no superview. Please ensure that a superview first exists, or use constrain(:relation:to:multiplier:priority).")
+            guard let owningView = owningView else {
+                fatalError("Attempting to constrain a \(anchor) anchor using only a constant to an item that has no owningView or superview. Please ensure that an owningView or superview first exists, or use constrain(:relation:to:multiplier:priority).")
             }
-            return constrain(anchor, relation: relation, to: superview, priority: priority).offset(constant)
+            return constrain(anchor, relation: relation, to: owningView, priority: priority).offset(constant)
         }
     }
 

--- a/AnchorKit/Anchorable.swift
+++ b/AnchorKit/Anchorable.swift
@@ -50,6 +50,9 @@ public protocol Anchorable {
 
     /// Runs any methods that might be necessary or convenient before adding constraints. Called every time a constraint is added.
     func prepareForConstraints()
+
+    /// The view that owns this item. For layout guides, this returns `owningView`. For views, this returns the `superview`.
+    var owningView: View? { get }
 }
 
 extension LayoutGuide: Anchorable { }
@@ -76,5 +79,9 @@ extension View: ViewAnchorable {
         translatesAutoresizingMaskIntoConstraints = false
     }
 
-}
+    /// The `superview`.
+    public var owningView: View? {
+        return superview
+    }
 
+}

--- a/AnchorKit/LayoutPriority.swift
+++ b/AnchorKit/LayoutPriority.swift
@@ -101,7 +101,7 @@ extension View {
      - parameter    priority:       The new priority.
      - parameter    axis:           The axis for which the compression resistance priority should be set.
      */
-    public func setContentCompressionResistancePriority(_ priority: LayoutPriority, for axis: Axis) {
+    public func resistCompression(with priority: LayoutPriority, for axis: Axis) {
         setContentCompressionResistancePriority(priority.rawValue, for: axis)
     }
 
@@ -110,7 +110,7 @@ extension View {
      - parameter    priority:       The new priority.
      - parameter    axis:           The axis for which the content hugging priority should be set.
      */
-    public func setContentHuggingPriority(_ priority: LayoutPriority, for axis: Axis) {
+    public func hug(with priority: LayoutPriority, for axis: Axis) {
         setContentHuggingPriority(priority.rawValue, for: axis)
     }
 
@@ -119,7 +119,7 @@ extension View {
      - parameter    axis:   The axis of the view that might be reduced.
      - returns:             The priority with which the view should resist being compressed from its intrinsic size on the specified axis.
     */
-    public func contentCompressionResistancePriority(for axis: Axis) -> LayoutPriority {
+    public func compressionResistancePriority(for axis: Axis) -> LayoutPriority {
         return LayoutPriority(rawValue: contentCompressionResistancePriority(for: axis))
     }
 
@@ -128,7 +128,7 @@ extension View {
      - parameter    axis:   The axis of the view that might be enlarged.
      - returns:             The priority with which the view should resist being enlarged from its intrinsic size on the specified axis.
      */
-    public func contentHuggingPriority(for axis: Axis) -> LayoutPriority {
+    public func huggingPriority(for axis: Axis) -> LayoutPriority {
         return LayoutPriority(rawValue: contentHuggingPriority(for: axis))
     }
 

--- a/AnchorKitTests/Anchorable_Tests.swift
+++ b/AnchorKitTests/Anchorable_Tests.swift
@@ -37,6 +37,18 @@ class Anchorable_Tests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Owning View
+
+    func testLayoutGuide_owningView() {
+        let layoutGuide = UILayoutGuide()
+        view1.addLayoutGuide(layoutGuide)
+        XCTAssertEqual((layoutGuide as Anchorable).owningView, view1)
+    }
+
+    func testView_owningView() {
+        XCTAssertEqual(view1.owningView, superview)
+    }
+
     // MARK: - Prepare for constraints
 
     func testMakeConstraint_twoAxisAnchors_preparesForConstraints() {
@@ -125,11 +137,21 @@ class Anchorable_Tests: XCTestCase {
         XCTAssertEqual(constraint.relation, .equal)
     }
 
-    func testConstrainLeadingToConstant() {
+    func testConstrainLeadingToConstant_view() {
         let constraint = view1.constrain(.leading, toConstant: 20)
         XCTAssertEqual(constraint.constant, 20)
         XCTAssertEqual(constraint.firstAnchor, view1.leadingAnchor)
         XCTAssertEqual(constraint.secondAnchor, superview.leadingAnchor)
+        XCTAssertEqual(constraint.relation, .equal)
+    }
+
+    func testConstrainLeadingToConstant_layoutGuide() {
+        let layoutGuide = UILayoutGuide()
+        view1.addLayoutGuide(layoutGuide)
+        let constraint = layoutGuide.constrain(.leading, toConstant: 20)
+        XCTAssertEqual(constraint.constant, 20)
+        XCTAssertEqual(constraint.firstAnchor, layoutGuide.leadingAnchor)
+        XCTAssertEqual(constraint.secondAnchor, view1.leadingAnchor)
         XCTAssertEqual(constraint.relation, .equal)
     }
 

--- a/AnchorKitTests/LayoutPriority_Tests.swift
+++ b/AnchorKitTests/LayoutPriority_Tests.swift
@@ -57,15 +57,15 @@ class LayoutPriority_Tests: XCTestCase {
 
     func testContentCompressionResistance() {
         let v = View()
-        v.setContentCompressionResistancePriority(.high, for: .vertical)
-        XCTAssertEqual(v.contentCompressionResistancePriority(for: .vertical), .high)
+        v.resistCompression(with: .high, for: .vertical)
+        XCTAssertEqual(v.compressionResistancePriority(for: .vertical), .high)
         XCTAssertEqual(v.contentCompressionResistancePriority(for: .vertical), 750)
     }
 
     func testContentHugging() {
         let v = View()
-        v.setContentHuggingPriority(.medium, for: .horizontal)
-        XCTAssertEqual(v.contentHuggingPriority(for: .horizontal), .medium)
+        v.hug(with: .medium, for: .horizontal)
+        XCTAssertEqual(v.huggingPriority(for: .horizontal), .medium)
         XCTAssertEqual(v.contentHuggingPriority(for: .horizontal), 500)
     }
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ public func constrain(_ anchor: Anchor, relation: NSLayoutRelation = .equal, toC
 public func constrain(_ anchors: Anchor..., relation: NSLayoutRelation = .equal, toConstant constant: CGFloatRepresentable, priority: LayoutPriority = .required) -> [NSLayoutConstraint]
 ````
 
-This method can also work on *views* (not layout guides) with anchors other than `width` and `height`. The resulting behavior is equivalent to constraining the anchor to the corresponding anchor on the view's superview. So `myView.constrain(.leading, toConstant: 10)` translates to `myView.constrain(.leading, to: myView.superview!).offset(10)`.
+This method can also work on items with anchors other than `width` and `height`. The resulting behavior is equivalent to constraining the anchor to the corresponding anchor on the view's `superview` (or layout guide's `owningView`). So `myView.constrain(.leading, toConstant: 10)` translates to `myView.constrain(.leading, to: myView.superview!).offset(10)`.
 
 
 ### Constrain To Edges
@@ -253,7 +253,8 @@ topConstraint.layoutPriority = .high
 And finally, use layout priorites to set your content compression resistance and content hugging:
 
 ````swift
-myView.setContentHuggingPriority(.low, for: .vertical)
+myView.hug(with: .low, for: .vertical)
+myView.resistCompression(with: .high, for: .horizontal)
 ````
 
 ## Other Goodies


### PR DESCRIPTION
- `Anchorable.owningView` now represents `UILayoutGuide.owningView` and `UIView.superview`
- Renamed content hugging and compression resistance methods