### PR TITLE
Fix autoresizing masks

### DIFF
--- a/AnchorKit/Anchorable+Constraints.swift
+++ b/AnchorKit/Anchorable+Constraints.swift
@@ -32,9 +32,9 @@ extension Anchorable {
 
         if let firstDimension = firstAnchor as? NSLayoutAnchor<NSLayoutDimension> as? NSLayoutDimension,
             let secondDimension = secondAnchor as? NSLayoutAnchor<NSLayoutDimension> as? NSLayoutDimension {
-            return makeConstraint(firstDimension, relation: relation, to: secondDimension, of: item, multiplier: multiplier, priority: priority)
+            return makeConstraint(firstDimension, relation: relation, to: secondDimension, multiplier: multiplier, priority: priority)
         } else {
-            return makeConstraint(firstAnchor, relation: relation, to: secondAnchor, of: item, priority: priority)
+            return makeConstraint(firstAnchor, relation: relation, to: secondAnchor, priority: priority)
         }
     }
 
@@ -130,9 +130,8 @@ extension Anchorable {
 
     // MARK: - Helpers
 
-    func makeConstraint<ObjectType: AnyObject>(_ anchor: NSLayoutAnchor<ObjectType>, relation: NSLayoutRelation, to otherAnchor: NSLayoutAnchor<ObjectType>, of otherView: Anchorable, priority: LayoutPriority) -> NSLayoutConstraint {
+    func makeConstraint<ObjectType: AnyObject>(_ anchor: NSLayoutAnchor<ObjectType>, relation: NSLayoutRelation, to otherAnchor: NSLayoutAnchor<ObjectType>, priority: LayoutPriority) -> NSLayoutConstraint {
         prepareForConstraints()
-        otherView.prepareForConstraints()
 
         let constraint: NSLayoutConstraint
         switch relation {
@@ -145,9 +144,8 @@ extension Anchorable {
         return constraint.activate()
     }
 
-    func makeConstraint(_ dimension: NSLayoutDimension, relation: NSLayoutRelation, to otherDimension: NSLayoutDimension, of otherView: Anchorable, multiplier: CGFloatRepresentable, priority: LayoutPriority) -> NSLayoutConstraint {
+    func makeConstraint(_ dimension: NSLayoutDimension, relation: NSLayoutRelation, to otherDimension: NSLayoutDimension, multiplier: CGFloatRepresentable, priority: LayoutPriority) -> NSLayoutConstraint {
         prepareForConstraints()
-        otherView.prepareForConstraints()
 
         let constraint: NSLayoutConstraint
         switch relation {

--- a/AnchorKitTests/Anchorable_Tests.swift
+++ b/AnchorKitTests/Anchorable_Tests.swift
@@ -52,23 +52,23 @@ class Anchorable_Tests: XCTestCase {
     // MARK: - Prepare for constraints
 
     func testMakeConstraint_twoAxisAnchors_preparesForConstraints() {
-        _ = view1.makeConstraint(view1.leadingAnchor, relation: .equal, to: view2.trailingAnchor, of: view2, priority: .required)
+        _ = view1.makeConstraint(view1.leadingAnchor, relation: .equal, to: view2.trailingAnchor, priority: .required)
         XCTAssertFalse(view1.translatesAutoresizingMaskIntoConstraints)
-        XCTAssertFalse(view2.translatesAutoresizingMaskIntoConstraints)
+        XCTAssertTrue(view2.translatesAutoresizingMaskIntoConstraints)
     }
 
     func testMakeConstraint_twoDimensionAnchors_preparesForConstraints() {
-        _ = view1.makeConstraint(view1.widthAnchor, relation: .equal, to: view2.heightAnchor, of: view2, multiplier: 1, priority: .required)
+        _ = view1.makeConstraint(view1.widthAnchor, relation: .equal, to: view2.heightAnchor, multiplier: 1, priority: .required)
         XCTAssertFalse(view1.translatesAutoresizingMaskIntoConstraints)
-        XCTAssertFalse(view2.translatesAutoresizingMaskIntoConstraints)
+        XCTAssertTrue(view2.translatesAutoresizingMaskIntoConstraints)
     }
 
     // MARK: - Activation
 
     func testMakeConstraint_twoAxisAnchors_isActive() {
-        let equalConstraint = view1.makeConstraint(view1.leadingAnchor, relation: .equal, to: view2.trailingAnchor, of: view2, priority: .required)
-        let greaterConstraint = view1.makeConstraint(view1.leadingAnchor, relation: .greaterThanOrEqual, to: view2.trailingAnchor, of: view2, priority: .required)
-        let lessConstraint = view1.makeConstraint(view1.leadingAnchor, relation: .lessThanOrEqual, to: view2.trailingAnchor, of: view2, priority: .required)
+        let equalConstraint = view1.makeConstraint(view1.leadingAnchor, relation: .equal, to: view2.trailingAnchor, priority: .required)
+        let greaterConstraint = view1.makeConstraint(view1.leadingAnchor, relation: .greaterThanOrEqual, to: view2.trailingAnchor, priority: .required)
+        let lessConstraint = view1.makeConstraint(view1.leadingAnchor, relation: .lessThanOrEqual, to: view2.trailingAnchor, priority: .required)
         XCTAssert(equalConstraint.isActive)
         XCTAssert(greaterConstraint.isActive)
         XCTAssert(lessConstraint.isActive)
@@ -78,9 +78,9 @@ class Anchorable_Tests: XCTestCase {
     }
 
     func testMakeConstraint_twoDimensionAnchors_isActive() {
-        let equalConstraint = view1.makeConstraint(view1.widthAnchor, relation: .equal, to: view2.heightAnchor, of: view2, multiplier: 1, priority: .required)
-        let greaterConstraint = view1.makeConstraint(view1.widthAnchor, relation: .greaterThanOrEqual, to: view2.heightAnchor, of: view2, multiplier: 1, priority: .required)
-        let lessConstraint = view1.makeConstraint(view1.widthAnchor, relation: .lessThanOrEqual, to: view2.heightAnchor, of: view2, multiplier: 1, priority: .required)
+        let equalConstraint = view1.makeConstraint(view1.widthAnchor, relation: .equal, to: view2.heightAnchor, multiplier: 1, priority: .required)
+        let greaterConstraint = view1.makeConstraint(view1.widthAnchor, relation: .greaterThanOrEqual, to: view2.heightAnchor, multiplier: 1, priority: .required)
+        let lessConstraint = view1.makeConstraint(view1.widthAnchor, relation: .lessThanOrEqual, to: view2.heightAnchor, multiplier: 1, priority: .required)
         XCTAssert(equalConstraint.isActive)
         XCTAssert(greaterConstraint.isActive)
         XCTAssert(lessConstraint.isActive)
@@ -104,12 +104,12 @@ class Anchorable_Tests: XCTestCase {
     // MARK: - Priority
 
     func testMakeConstraint_twoAxisAnchors_setsPriority() {
-        let constraint = view1.makeConstraint(view1.leadingAnchor, relation: .equal, to: view2.trailingAnchor, of: view2, priority: .high)
+        let constraint = view1.makeConstraint(view1.leadingAnchor, relation: .equal, to: view2.trailingAnchor, priority: .high)
         XCTAssertEqual(constraint.priority, 750)
     }
 
     func testMakeConstraint_twoDimensionAnchors_setsPriority() {
-        let constraint = view1.makeConstraint(view1.widthAnchor, relation: .equal, to: view2.heightAnchor, of: view2, multiplier: 1, priority: .low)
+        let constraint = view1.makeConstraint(view1.widthAnchor, relation: .equal, to: view2.heightAnchor, multiplier: 1, priority: .low)
         XCTAssertEqual(constraint.priority, 250)
     }
 


### PR DESCRIPTION
We only want to call `translatesAutoresizingMasksIntoConstraints = false` on the view that we are actually calling `constrain(...)` on. A view controller's view, for example, has this property set to `true` by default, and usually should not be changed.