### PR TITLE
Swift Package Manager Support

### DIFF
--- a/AnchorKit/Source/CGFloatRepresentable.swift
+++ b/AnchorKit/Source/CGFloatRepresentable.swift
@@ -8,6 +8,10 @@
 
 import CoreGraphics
 
+#if SWIFT_PACKAGE
+import Foundation
+#endif
+
 /**
  A protocol that converts different number types to a `CGFloat` equivalent.
  

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,22 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+let package = Package(
+    name: "AnchorKit",
+    platforms: [
+        .iOS(.v9),
+        .macOS(.v10_12),
+        .tvOS(.v9)
+    ],
+    products: [
+        .library(name: "AnchorKit", targets: ["AnchorKit"]),
+    ],
+    targets: [
+        .target(name: "AnchorKit", path: "AnchorKit/Source"),
+        .testTarget(name: "AnchorKitTests", dependencies: ["AnchorKit"], path: "AnchorKitTests"),
+    ],
+    swiftLanguageVersions: [
+        .v5
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ let topAndSideConstraints = myView.constrain(.leading, .trailing, .top, to: anot
 
 # Requirements
 
-- iOS 9.0+, macOS 10.11+, tvOS 9.0+
+- iOS 9.0+, macOS 10.12+, tvOS 9.0+
 - Swift 3.1+
 - Xcode 8+
 
@@ -80,6 +80,11 @@ pod 'AnchorKit'
 ### Carthage:
 ````
 github "Weebly/AnchorKit"
+````
+
+### Swift Package Manager:
+````
+package(url: "https://github.com/Weebly/AnchorKit.git", .branch("master"))
 ````
 
 # Usage


### PR DESCRIPTION
Adds a `Package.swift` to support SPM.
Bumps MacOS to 10.12 as the package would not compile on 10.11.
Tested by importing my forked branch in my Xcode project.

## Test
`swift run`
`swift test`

## Note
The README uses `master` for the package definition, as no tagged version supports SPM yet. This tag needs to be updated when `2.3.0` is released:
`.package(url: "https://github.com/Weebly/AnchorKit.git", from: "2.3.0")` 
